### PR TITLE
Fix FirebaseCore.def

### DIFF
--- a/firebase-app/src/iosMain/c_interop/FirebaseCore.def
+++ b/firebase-app/src/iosMain/c_interop/FirebaseCore.def
@@ -1,4 +1,4 @@
 language = Objective-C
 modules = FirebaseCore
 compilerOpts = -framework FirebaseCore
-linkerOpts = -framework FirebaseCore -framework FIRAnalyticsConnector -framework FirebaseAnalytics -framework FirebaseCore -framework FirebaseCoreDiagnostics -framework FirebaseInstallations -framework FirebaseInstanceID -framework GoogleAppMeasurement -framework GoogleDataTransport -framework GoogleDataTransportCCTSupport -framework GoogleUtilities -framework PromisesObjC -framework nanopb -framework StoreKit -lsqlite3
+linkerOpts = -framework FirebaseCore -framework abseil -framework gRPC-Core -framework gRPC-C++ -framework BoringSSL-GRPC -framework leveldb-library -framework GoogleUtilities -framework SystemConfiguration -framework FIRAnalyticsConnector -framework FirebaseAnalytics -framework FirebaseCore -framework FirebaseCoreDiagnostics -framework FirebaseInstallations -framework FirebaseInstanceID -framework GoogleAppMeasurement -framework GoogleDataTransport -framework GoogleUtilities -framework PromisesObjC -framework nanopb -framework StoreKit -lsqlite3


### PR DESCRIPTION
This one will fix `ld: symbol(s) not found for architecture x86_64` errors while building iOS Framework