### PR TITLE
Common Timestamp, FieldValue.serverTimestamp and Serializers fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ firebase-firestore/src/iosMain/c_interop/modules/
 firebase-database/src/iosMain/c_interop/modules/
 Firebase*.zip
 /Firebase
-/.DS_Store
+.DS_Store
 
 
 /**/Cartfile.resolved

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:4.0.1")
         classpath("de.undercouch:gradle-download-task:4.0.4")
         classpath("com.adarshr:gradle-test-logger-plugin:2.0.0")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:1.3.71")
     }
 }
 

--- a/firebase-app/src/androidMain/kotlin/dev/gitlive/firebase/firebase.kt
+++ b/firebase-app/src/androidMain/kotlin/dev/gitlive/firebase/firebase.kt
@@ -33,11 +33,32 @@ actual class FirebaseApp internal constructor(val android: com.google.firebase.F
     actual val name: String
         get() = android.name
     actual val options: FirebaseOptions
-        get() = android.options.run { FirebaseOptions(applicationId, apiKey, databaseUrl, gaTrackingId, storageBucket, projectId) }
+        get() = android.options.run { FirebaseOptions(applicationId, apiKey, databaseUrl, gaTrackingId, storageBucket, projectId, gcmSenderId) }
 }
 
 actual fun Firebase.apps(context: Any?) = com.google.firebase.FirebaseApp.getApps(context as Context)
     .map { FirebaseApp(it) }
+
+actual class FirebaseOptions actual constructor(
+    actual val applicationId: String,
+    actual val apiKey: String,
+    actual val databaseUrl: String?,
+    actual val gaTrackingId: String?,
+    actual val storageBucket: String?,
+    actual val projectId: String?,
+    actual val gcmSenderId: String?
+) {
+    actual companion object {
+        actual fun withContext(context: Any): FirebaseOptions? {
+            return when (context) {
+                is Context -> com.google.firebase.FirebaseOptions.fromResource(context)
+                else -> com.google.firebase.FirebaseOptions.Builder().build()
+            }?.run {
+                FirebaseOptions(applicationId, apiKey, databaseUrl, gaTrackingId, storageBucket, projectId, gcmSenderId)
+            }
+        }
+    }
+}
 
 private fun FirebaseOptions.toAndroid() = com.google.firebase.FirebaseOptions.Builder()
     .setApplicationId(applicationId)

--- a/firebase-app/src/commonMain/kotlin/dev/gitlive/firebase/firebase.kt
+++ b/firebase-app/src/commonMain/kotlin/dev/gitlive/firebase/firebase.kt
@@ -43,15 +43,27 @@ expect fun Firebase.initialize(context: Any? = null, options: FirebaseOptions, n
 val Firebase.options: FirebaseOptions
     get() = Firebase.app.options
 
-data class FirebaseOptions(
-    val applicationId: String,
-    val apiKey: String,
-    val databaseUrl: String? = null,
-    val gaTrackingId: String? = null,
-    val storageBucket: String? = null,
-    val projectId: String? = null,
-    val gcmSenderId: String? = null
-)
+expect class FirebaseOptions(
+    applicationId: String,
+    apiKey: String,
+    databaseUrl: String? = null,
+    gaTrackingId: String? = null,
+    storageBucket: String? = null,
+    projectId: String? = null,
+    gcmSenderId: String? = null
+) {
+    val applicationId: String
+    val apiKey: String
+    val databaseUrl: String?
+    val gaTrackingId: String?
+    val storageBucket: String?
+    val projectId: String?
+    val gcmSenderId: String?
+
+    companion object {
+        fun withContext(context: Any): FirebaseOptions?
+    }
+}
 
 expect open class FirebaseException : Exception
 

--- a/firebase-app/src/iosMain/kotlin/dev/gitlive/firebase/firebase.kt
+++ b/firebase-app/src/iosMain/kotlin/dev/gitlive/firebase/firebase.kt
@@ -30,13 +30,34 @@ actual class FirebaseApp internal constructor(val ios: FIRApp) {
     actual val name: String
         get() = ios.name
     actual val options: FirebaseOptions
-        get() = ios.options.run { FirebaseOptions(bundleID, APIKey!!, databaseURL!!, trackingID, storageBucket, projectID) }
+        get() = ios.options.run { FirebaseOptions(bundleID, APIKey!!, databaseURL!!, trackingID, storageBucket, projectID, GCMSenderID) }
 }
 
 actual fun Firebase.apps(context: Any?) = FIRApp.allApps()
     .orEmpty()
     .values
     .map { FirebaseApp(it as FIRApp) }
+
+actual class FirebaseOptions actual constructor(
+    actual val applicationId: String,
+    actual val apiKey: String,
+    actual val databaseUrl: String?,
+    actual val gaTrackingId: String?,
+    actual val storageBucket: String?,
+    actual val projectId: String?,
+    actual val gcmSenderId: String?
+) {
+    actual companion object {
+        actual fun withContext(context: Any): FirebaseOptions? {
+            return when (context) {
+                is String -> FIROptions(contentsOfFile = context)
+                else -> FIROptions.defaultOptions()
+            }?.run {
+                FirebaseOptions(googleAppID!!, APIKey!!, databaseURL, trackingID, storageBucket, projectID, GCMSenderID)
+            }
+        }
+    }
+}
 
 private fun FirebaseOptions.toIos() = FIROptions(this@toIos.applicationId, this@toIos.gcmSenderId ?: "").apply {
         APIKey = this@toIos.apiKey

--- a/firebase-app/src/jsMain/kotlin/dev/gitlive/firebase/firebase.kt
+++ b/firebase-app/src/jsMain/kotlin/dev/gitlive/firebase/firebase.kt
@@ -32,6 +32,20 @@ actual class FirebaseApp internal constructor(val js: firebase.App) {
 
 actual fun Firebase.apps(context: Any?) = firebase.apps.map { FirebaseApp(it) }
 
+actual class FirebaseOptions actual constructor(
+    actual val applicationId: String,
+    actual val apiKey: String,
+    actual val databaseUrl: String?,
+    actual val gaTrackingId: String?,
+    actual val storageBucket: String?,
+    actual val projectId: String?,
+    actual val gcmSenderId: String?
+) {
+    actual companion object {
+        actual fun withContext(context: Any): FirebaseOptions? = null
+    }
+}
+
 private fun FirebaseOptions.toJson() = json(
     "apiKey" to apiKey,
     "applicationId" to applicationId,

--- a/firebase-common/build.gradle.kts
+++ b/firebase-common/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("com.android.library")
     kotlin("multiplatform")
     kotlin("native.cocoapods")
-    kotlin("plugin.serialization") version "1.3.71"
+    kotlin("plugin.serialization")
 }
 
 android {

--- a/firebase-common/src/androidMain/kotlin/dev/gitlive/firebase/_decoders.kt
+++ b/firebase-common/src/androidMain/kotlin/dev/gitlive/firebase/_decoders.kt
@@ -10,13 +10,39 @@ import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.StructureKind
 
 actual fun FirebaseDecoder.structureDecoder(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder = when(descriptor.kind as StructureKind) {
-        StructureKind.CLASS, StructureKind.OBJECT -> (value as Map<*, *>).let { map ->
-            FirebaseClassDecoder(map.size, { map.containsKey(it) }) { desc, index -> map[desc.getElementName(index)] }
+    StructureKind.CLASS, StructureKind.OBJECT -> when {
+        value is Map<*, *> ->
+            FirebaseClassDecoder(value.size, { value.containsKey(it) }) { desc, index ->
+                value[desc.getElementName(index)]
+            }
+        value != null && value::class.qualifiedName == "com.google.firebase.Timestamp" -> {
+            makeJavaReflectionDecoder(value)
         }
-        StructureKind.LIST -> (value as List<*>).let {
-            FirebaseCompositeDecoder(it.size) { _, index -> it[index] }
-        }
-        StructureKind.MAP -> (value as Map<*, *>).entries.toList().let {
-            FirebaseCompositeDecoder(it.size) { _, index -> it[index/2].run { if(index % 2 == 0) key else value }  }
+        else -> FirebaseEmptyCompositeDecoder()
+    }
+    StructureKind.LIST -> (value as List<*>).let {
+        FirebaseCompositeDecoder(it.size) { _, index -> it[index] }
+    }
+    StructureKind.MAP -> (value as Map<*, *>).entries.toList().let {
+        FirebaseCompositeDecoder(it.size) { _, index -> it[index / 2].run { if (index % 2 == 0) key else value } }
+    }
+}
+
+private val timestampKeys = setOf("seconds", "nanoseconds")
+
+private fun makeJavaReflectionDecoder(jvmObj: Any): CompositeDecoder {
+    val timestampClass = Class.forName("com.google.firebase.Timestamp")
+    val getSeconds = timestampClass.getMethod("getSeconds")
+    val getNanoseconds = timestampClass.getMethod("getNanoseconds")
+
+    return FirebaseClassDecoder(
+        size = 2,
+        containsKey = { timestampKeys.contains(it) }
+    ) { descriptor, index ->
+        when (descriptor.getElementName(index)) {
+            "seconds" -> getSeconds.invoke(jvmObj) as Long
+            "nanoseconds" -> getNanoseconds.invoke(jvmObj) as Int
+            else -> null
         }
     }
+}

--- a/firebase-common/src/androidMain/kotlin/dev/gitlive/firebase/_encoders.kt
+++ b/firebase-common/src/androidMain/kotlin/dev/gitlive/firebase/_encoders.kt
@@ -16,7 +16,8 @@ actual fun FirebaseEncoder.structureEncoder(descriptor: SerialDescriptor, vararg
         .let { FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity) { _, index, value -> it.add(index, value) } }
     StructureKind.MAP -> mutableListOf<Any?>()
         .let { FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity, { value = it.chunked(2).associate { (k, v) -> k to v } }) { _, _, value -> it.add(value) } }
-    StructureKind.CLASS,  StructureKind.OBJECT -> mutableMapOf<Any?, Any?>()
+    StructureKind.CLASS -> mutableMapOf<Any?, Any?>()
         .also { value = it }
         .let { FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity) { _, index, value -> it[descriptor.getElementName(index)] = value } }
+    StructureKind.OBJECT -> FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity) { _, _, obj -> value = obj }
 }

--- a/firebase-common/src/commonMain/kotlin/dev/gitlive/firebase/decoders.kt
+++ b/firebase-common/src/commonMain/kotlin/dev/gitlive/firebase/decoders.kt
@@ -80,6 +80,8 @@ class FirebaseClassDecoder(
             ?: READ_DONE
 }
 
+open class FirebaseEmptyCompositeDecoder(): FirebaseCompositeDecoder(0, { _, _ -> })
+
 open class FirebaseCompositeDecoder constructor(
     private val size: Int,
     private val get: (descriptor: SerialDescriptor, index: Int) -> Any?

--- a/firebase-common/src/commonMain/kotlin/dev/gitlive/firebase/encoders.kt
+++ b/firebase-common/src/commonMain/kotlin/dev/gitlive/firebase/encoders.kt
@@ -111,6 +111,8 @@ open class FirebaseCompositeEncoder constructor(
     override fun <T> encodeSerializableElement(descriptor: SerialDescriptor, index: Int, serializer: SerializationStrategy<T>, value: T)  =
         set(descriptor, index, FirebaseEncoder(shouldEncodeElementDefault, positiveInfinity).apply { encode(serializer, value) }.value)
 
+    fun <T> encodeObject(descriptor: SerialDescriptor, index: Int, value: T) = set(descriptor, index, value)
+
     override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) = set(descriptor, index, value)
 
     override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte) = set(descriptor, index, value)

--- a/firebase-common/src/iosMain/kotlin/dev/gitlive/firebase/_decoders.kt
+++ b/firebase-common/src/iosMain/kotlin/dev/gitlive/firebase/_decoders.kt
@@ -8,10 +8,19 @@ import kotlinx.serialization.CompositeDecoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.StructureKind
+import platform.Foundation.*
+import platform.darwin.NSObject
 
 actual fun FirebaseDecoder.structureDecoder(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder = when(descriptor.kind as StructureKind) {
-    StructureKind.CLASS, StructureKind.OBJECT -> (value as Map<*, *>).let { map ->
-        FirebaseClassDecoder(map.size, { map.containsKey(it) }) { desc, index -> map[desc.getElementName(index)] }
+    StructureKind.CLASS, StructureKind.OBJECT -> when {
+        value is Map<*, *> ->
+            FirebaseClassDecoder(value.size, { value.containsKey(it) }) { desc, index ->
+                value[desc.getElementName(index)]
+            }
+        value is NSObject && NSClassFromString("FIRTimestamp") == value.`class`() -> {
+            makeFIRTimestampDecoder(value)
+        }
+        else -> FirebaseEmptyCompositeDecoder()
     }
     StructureKind.LIST -> (value as List<*>).let {
         FirebaseCompositeDecoder(it.size) { _, index -> it[index] }
@@ -19,4 +28,12 @@ actual fun FirebaseDecoder.structureDecoder(descriptor: SerialDescriptor, vararg
     StructureKind.MAP -> (value as Map<*, *>).entries.toList().let {
         FirebaseCompositeDecoder(it.size) { _, index -> it[index/2].run { if(index % 2 == 0) key else value }  }
     }
+}
+
+private val timestampKeys = setOf("seconds", "nanoseconds")
+private fun makeFIRTimestampDecoder(objcObj: NSObject) = FirebaseClassDecoder(
+    size = 2,
+    containsKey = { timestampKeys.contains(it) }
+) { descriptor, index ->
+    objcObj.valueForKeyPath(descriptor.getElementName(index))
 }

--- a/firebase-common/src/iosMain/kotlin/dev/gitlive/firebase/_encoders.kt
+++ b/firebase-common/src/iosMain/kotlin/dev/gitlive/firebase/_encoders.kt
@@ -16,7 +16,8 @@ actual fun FirebaseEncoder.structureEncoder(descriptor: SerialDescriptor, vararg
         .let { FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity) { _, index, value -> it.add(index, value) } }
     StructureKind.MAP -> mutableListOf<Any?>()
         .let { FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity, { value = it.chunked(2).associate { (k, v) -> k to v } }) { _, _, value -> it.add(value) } }
-    StructureKind.CLASS,  StructureKind.OBJECT -> mutableMapOf<Any?, Any?>()
+    StructureKind.CLASS -> mutableMapOf<Any?, Any?>()
         .also { value = it }
         .let { FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity) { _, index, value -> it[descriptor.getElementName(index)] = value } }
+    StructureKind.OBJECT -> FirebaseCompositeEncoder(shouldEncodeElementDefault, positiveInfinity) { _, _, obj -> value = obj }
 }

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -176,6 +176,7 @@ external object firebase {
             fun <T> runTransaction(func: (transaction: Transaction) -> Promise<T>): Promise<T>
             fun batch(): WriteBatch
             fun collection(collectionPath: String): CollectionReference
+            fun collectionGroup(collectionId: String): Query
             fun doc(documentPath: String): DocumentReference
             fun settings(settings: Json)
             fun enablePersistence(): Promise<Unit>

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -250,6 +250,7 @@ external object firebase {
                 fun delete(): FieldValue
                 fun arrayRemove(vararg elements: Any): FieldValue
                 fun arrayUnion(vararg elements: Any): FieldValue
+                fun serverTimestamp(): FieldValue
             }
         }
     }

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -237,6 +237,14 @@ external object firebase {
             fun delete(documentReference: DocumentReference): Transaction
         }
 
+        open class Timestamp {
+            companion object {
+                fun now(): Timestamp
+            }
+            val seconds: Long
+            val nanoseconds: Int
+        }
+
         abstract class FieldValue {
             companion object {
                 fun delete(): FieldValue

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -237,7 +237,7 @@ external object firebase {
             fun delete(documentReference: DocumentReference): Transaction
         }
 
-        open class Timestamp {
+        open class Timestamp(seconds: Long, nanoseconds: Int) {
             companion object {
                 fun now(): Timestamp
             }

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     kotlin("multiplatform")
     kotlin("native.cocoapods")
+    kotlin("plugin.serialization")
 }
 
 android {

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -2,6 +2,6 @@ package dev.gitlive.firebase.firestore
 
 actual typealias Timestamp = com.google.firebase.Timestamp
 
-actual fun Timestamp.now(): Timestamp = Timestamp.now()
+actual fun timestampNow(): Timestamp = Timestamp.now()
 actual val Timestamp.seconds: Long get() = seconds
 actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -1,0 +1,7 @@
+package dev.gitlive.firebase.firestore
+
+actual typealias Timestamp = com.google.firebase.Timestamp
+
+actual fun Timestamp.now(): Timestamp = Timestamp.now()
+actual val Timestamp.seconds: Long get() = seconds
+actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -3,5 +3,6 @@ package dev.gitlive.firebase.firestore
 actual typealias Timestamp = com.google.firebase.Timestamp
 
 actual fun timestampNow(): Timestamp = Timestamp.now()
+actual fun timestampWith(seconds: Long, nanoseconds: Int) = Timestamp(seconds, nanoseconds)
 actual val Timestamp.seconds: Long get() = seconds
 actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -35,6 +35,8 @@ actual class FirebaseFirestore(val android: com.google.firebase.firestore.Fireba
 
     actual fun document(documentPath: String) = DocumentReference(android.document(documentPath))
 
+    actual fun collectionGroup(collectionId: String) = Query(android.collectionGroup(collectionId))
+
     actual fun batch() = WriteBatch(android.batch())
 
     actual fun setLoggingEnabled(loggingEnabled: Boolean) =

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -322,11 +322,11 @@ actual class CollectionReference(override val android: com.google.firebase.fires
     actual val path: String
         get() = android.path
 
-    actual suspend fun add(data: Any, encodeDefaults: Boolean) =
-        DocumentReference(android.add(encode(data, encodeDefaults)!!).await())
+    actual suspend fun add(data: Any, encodeDefaults: Boolean, positiveInfinity: Any) =
+        DocumentReference(android.add(encode(data, encodeDefaults, positiveInfinity)!!).await())
 
-    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
-        DocumentReference(android.add(encode(strategy, data, encodeDefaults)!!).await())
+    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean, positiveInfinity: Any) =
+        DocumentReference(android.add(encode(strategy, data, encodeDefaults, positiveInfinity)!!).await())
 }
 
 actual typealias FirebaseFirestoreException = com.google.firebase.firestore.FirebaseFirestoreException

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -322,11 +322,11 @@ actual class CollectionReference(override val android: com.google.firebase.fires
     actual val path: String
         get() = android.path
 
-    actual suspend fun add(data: Any, encodeDefaults: Boolean, positiveInfinity: Any) =
-        DocumentReference(android.add(encode(data, encodeDefaults, positiveInfinity)!!).await())
+    actual suspend fun add(data: Any, encodeDefaults: Boolean) =
+        DocumentReference(android.add(encode(data, encodeDefaults)!!).await())
 
-    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean, positiveInfinity: Any) =
-        DocumentReference(android.add(encode(strategy, data, encodeDefaults, positiveInfinity)!!).await())
+    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
+        DocumentReference(android.add(encode(strategy, data, encodeDefaults)!!).await())
 }
 
 actual typealias FirebaseFirestoreException = com.google.firebase.firestore.FirebaseFirestoreException

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -368,5 +368,6 @@ actual object FieldValue {
     actual fun delete(): Any = com.google.firebase.firestore.FieldValue.delete()
     actual fun arrayUnion(vararg elements: Any): Any = com.google.firebase.firestore.FieldValue.arrayUnion(*elements)
     actual fun arrayRemove(vararg elements: Any): Any = com.google.firebase.firestore.FieldValue.arrayRemove(*elements)
+    actual fun serverTimestamp(): Any = com.google.firebase.firestore.FieldValue.serverTimestamp()
 }
 

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseBaseTimestampSerializer.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseBaseTimestampSerializer.kt
@@ -1,0 +1,31 @@
+package dev.gitlive.firebase.firestore
+
+import dev.gitlive.firebase.FirebaseCompositeEncoder
+import kotlinx.serialization.Decoder
+import kotlinx.serialization.Encoder
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialDescriptor
+import kotlinx.serialization.StructureKind
+
+abstract class FirebaseBaseTimestampSerializer<T> : KSerializer<T> {
+
+    override val descriptor = object : SerialDescriptor {
+        val keys = listOf("seconds", "nanoseconds")
+        override val kind = StructureKind.OBJECT
+        override val serialName = "Timestamp"
+        override val elementsCount get() = 2
+        override fun getElementIndex(name: String) = keys.indexOf(name)
+        override fun getElementName(index: Int) = keys[index]
+        override fun getElementAnnotations(index: Int) = emptyList<Annotation>()
+        override fun getElementDescriptor(index: Int) = throw NotImplementedError()
+        override fun isElementOptional(index: Int) = false
+    }
+
+    override fun serialize(encoder: Encoder, value: T) {
+        val objectEncoder = encoder.beginStructure(descriptor) as FirebaseCompositeEncoder
+        objectEncoder.encodeObject(descriptor, 0, value)
+        objectEncoder.endStructure(descriptor)
+    }
+
+    abstract override fun deserialize(decoder: Decoder): T
+}

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseNullableTimestampSerializer.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseNullableTimestampSerializer.kt
@@ -1,0 +1,44 @@
+package dev.gitlive.firebase.firestore
+
+import dev.gitlive.firebase.FirebaseCompositeDecoder
+import dev.gitlive.firebase.FirebaseCompositeEncoder
+import kotlinx.serialization.Decoder
+import kotlinx.serialization.Encoder
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialDescriptor
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.StructureKind
+
+class FirebaseNullableTimestampSerializer : KSerializer<Timestamp?> {
+
+    override val descriptor = object : SerialDescriptor {
+        val keys = listOf("seconds", "nanoseconds")
+        override val kind = StructureKind.OBJECT
+        override val serialName = "Timestamp"
+        override val elementsCount get() = 2
+        override fun getElementIndex(name: String) = keys.indexOf(name)
+        override fun getElementName(index: Int) = keys[index]
+        override fun getElementAnnotations(index: Int) = emptyList<Annotation>()
+        override fun getElementDescriptor(index: Int) = throw NotImplementedError()
+        override fun isElementOptional(index: Int) = false
+    }
+
+    override fun serialize(encoder: Encoder, value: Timestamp?) {
+        val objectEncoder = encoder.beginStructure(descriptor) as FirebaseCompositeEncoder
+        objectEncoder.encodeObject(descriptor, 0, value)
+        objectEncoder.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): Timestamp? {
+        val objectDecoder = decoder.beginStructure(descriptor) as FirebaseCompositeDecoder
+        return try {
+            val seconds = objectDecoder.decodeLongElement(descriptor, 0)
+            val nanoseconds = objectDecoder.decodeIntElement(descriptor, 1)
+            objectDecoder.endStructure(descriptor)
+            timestampWith(seconds, nanoseconds)
+        } catch (exception: SerializationException) {
+            objectDecoder.endStructure(descriptor)
+            null
+        }
+    }
+}

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseNullableTimestampSerializer.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseNullableTimestampSerializer.kt
@@ -1,33 +1,10 @@
 package dev.gitlive.firebase.firestore
 
 import dev.gitlive.firebase.FirebaseCompositeDecoder
-import dev.gitlive.firebase.FirebaseCompositeEncoder
 import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.StructureKind
 
-class FirebaseNullableTimestampSerializer : KSerializer<Timestamp?> {
-
-    override val descriptor = object : SerialDescriptor {
-        val keys = listOf("seconds", "nanoseconds")
-        override val kind = StructureKind.OBJECT
-        override val serialName = "Timestamp"
-        override val elementsCount get() = 2
-        override fun getElementIndex(name: String) = keys.indexOf(name)
-        override fun getElementName(index: Int) = keys[index]
-        override fun getElementAnnotations(index: Int) = emptyList<Annotation>()
-        override fun getElementDescriptor(index: Int) = throw NotImplementedError()
-        override fun isElementOptional(index: Int) = false
-    }
-
-    override fun serialize(encoder: Encoder, value: Timestamp?) {
-        val objectEncoder = encoder.beginStructure(descriptor) as FirebaseCompositeEncoder
-        objectEncoder.encodeObject(descriptor, 0, value)
-        objectEncoder.endStructure(descriptor)
-    }
+class FirebaseNullableTimestampSerializer :FirebaseBaseTimestampSerializer<Timestamp?>() {
 
     override fun deserialize(decoder: Decoder): Timestamp? {
         val objectDecoder = decoder.beginStructure(descriptor) as FirebaseCompositeDecoder

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseTimestampSerializer.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseTimestampSerializer.kt
@@ -1,32 +1,9 @@
 package dev.gitlive.firebase.firestore
 
 import dev.gitlive.firebase.FirebaseCompositeDecoder
-import dev.gitlive.firebase.FirebaseCompositeEncoder
 import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
-import kotlinx.serialization.StructureKind
 
-class FirebaseTimestampSerializer : KSerializer<Timestamp> {
-
-    override val descriptor = object : SerialDescriptor {
-        val keys = listOf("seconds", "nanoseconds")
-        override val kind = StructureKind.OBJECT
-        override val serialName = "Timestamp"
-        override val elementsCount get() = 2
-        override fun getElementIndex(name: String) = keys.indexOf(name)
-        override fun getElementName(index: Int) = keys[index]
-        override fun getElementAnnotations(index: Int) = emptyList<Annotation>()
-        override fun getElementDescriptor(index: Int) = throw NotImplementedError()
-        override fun isElementOptional(index: Int) = false
-    }
-
-    override fun serialize(encoder: Encoder, value: Timestamp) {
-        val objectEncoder = encoder.beginStructure(descriptor) as FirebaseCompositeEncoder
-        objectEncoder.encodeObject(descriptor, 0, value)
-        objectEncoder.endStructure(descriptor)
-    }
+class FirebaseTimestampSerializer : FirebaseBaseTimestampSerializer<Timestamp>() {
 
     override fun deserialize(decoder: Decoder): Timestamp {
         val objectDecoder = decoder.beginStructure(descriptor) as FirebaseCompositeDecoder

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseTimestampSerializer.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseTimestampSerializer.kt
@@ -1,0 +1,38 @@
+package dev.gitlive.firebase.firestore
+
+import dev.gitlive.firebase.FirebaseCompositeDecoder
+import dev.gitlive.firebase.FirebaseCompositeEncoder
+import kotlinx.serialization.Decoder
+import kotlinx.serialization.Encoder
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialDescriptor
+import kotlinx.serialization.StructureKind
+
+class FirebaseTimestampSerializer : KSerializer<Timestamp> {
+
+    override val descriptor = object : SerialDescriptor {
+        val keys = listOf("seconds", "nanoseconds")
+        override val kind = StructureKind.OBJECT
+        override val serialName = "Timestamp"
+        override val elementsCount get() = 2
+        override fun getElementIndex(name: String) = keys.indexOf(name)
+        override fun getElementName(index: Int) = keys[index]
+        override fun getElementAnnotations(index: Int) = emptyList<Annotation>()
+        override fun getElementDescriptor(index: Int) = throw NotImplementedError()
+        override fun isElementOptional(index: Int) = false
+    }
+
+    override fun serialize(encoder: Encoder, value: Timestamp) {
+        val objectEncoder = encoder.beginStructure(descriptor) as FirebaseCompositeEncoder
+        objectEncoder.encodeObject(descriptor, 0, value)
+        objectEncoder.endStructure(descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): Timestamp {
+        val objectDecoder = decoder.beginStructure(descriptor) as FirebaseCompositeDecoder
+        val seconds = objectDecoder.decodeLongElement(descriptor, 0)
+        val nanoseconds = objectDecoder.decodeIntElement(descriptor, 1)
+        objectDecoder.endStructure(descriptor)
+        return timestampWith(seconds, nanoseconds)
+    }
+}

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -2,6 +2,6 @@ package dev.gitlive.firebase.firestore
 
 expect class Timestamp
 
-expect fun Timestamp.now(): Timestamp
+expect fun timestampNow(): Timestamp
 expect val Timestamp.seconds: Long
 expect val Timestamp.nanoseconds: Int

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -1,5 +1,8 @@
 package dev.gitlive.firebase.firestore
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 expect class Timestamp
 
 expect fun timestampNow(): Timestamp

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -3,5 +3,6 @@ package dev.gitlive.firebase.firestore
 expect class Timestamp
 
 expect fun timestampNow(): Timestamp
+expect fun timestampWith(seconds: Long, nanoseconds: Int): Timestamp
 expect val Timestamp.seconds: Long
 expect val Timestamp.nanoseconds: Int

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -1,0 +1,7 @@
+package dev.gitlive.firebase.firestore
+
+expect class Timestamp
+
+expect fun Timestamp.now(): Timestamp
+expect val Timestamp.seconds: Long
+expect val Timestamp.nanoseconds: Int

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -1,8 +1,5 @@
 package dev.gitlive.firebase.firestore
 
-import kotlinx.serialization.Serializable
-
-@Serializable
 expect class Timestamp
 
 expect fun timestampNow(): Timestamp

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -22,6 +22,7 @@ expect class FirebaseFirestore {
 //    var settings: FirebaseFirestoreSettings
     fun collection(collectionPath: String): CollectionReference
     fun document(documentPath: String): DocumentReference
+    fun collectionGroup(collectionId: String): Query
     fun batch(): WriteBatch
     fun setLoggingEnabled(loggingEnabled: Boolean)
     suspend fun clearPersistence()

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -130,8 +130,8 @@ expect class DocumentReference {
 expect class CollectionReference : Query {
     val path: String
     @ImplicitReflectionSerializer
-    suspend fun add(data: Any, encodeDefaults: Boolean = true): DocumentReference
-    suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true): DocumentReference
+    suspend fun add(data: Any, encodeDefaults: Boolean = true, positiveInfinity: Any = Double.POSITIVE_INFINITY): DocumentReference
+    suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true, positiveInfinity: Any = Double.POSITIVE_INFINITY): DocumentReference
 }
 
 expect class FirebaseFirestoreException : FirebaseException

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -188,6 +188,7 @@ expect object FieldValue {
     fun delete(): Any
     fun arrayUnion(vararg elements: Any): Any
     fun arrayRemove(vararg elements: Any): Any
+    fun serverTimestamp(): Any
 }
 
 

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -130,8 +130,8 @@ expect class DocumentReference {
 expect class CollectionReference : Query {
     val path: String
     @ImplicitReflectionSerializer
-    suspend fun add(data: Any, encodeDefaults: Boolean = true, positiveInfinity: Any = Double.POSITIVE_INFINITY): DocumentReference
-    suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true, positiveInfinity: Any = Double.POSITIVE_INFINITY): DocumentReference
+    suspend fun add(data: Any, encodeDefaults: Boolean = true): DocumentReference
+    suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true): DocumentReference
 }
 
 expect class FirebaseFirestoreException : FirebaseException

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/TimestampTests.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/TimestampTests.kt
@@ -11,7 +11,9 @@ import kotlinx.serialization.Serializable
 data class TestData(
     val uid: String,
     @Serializable(with = FirebaseTimestampSerializer::class)
-    val createdAt: Any
+    val createdAt: Any,
+    @Serializable(with = FirebaseNullableTimestampSerializer::class)
+    var updatedAt: Any?
 )
 
 @ImplicitReflectionSerializer
@@ -21,7 +23,7 @@ class TimestampTests {
     @Test
     fun encodeTimestampObject() = runTest {
         val timestamp = timestampWith(123, 456)
-        val item = TestData("uid123", timestamp)
+        val item = TestData("uid123", timestamp, null)
         val encoded = encode(item, shouldEncodeElementDefault = false) as Map<String, Any?>
         assertEquals("uid123", encoded["uid"])
         assertEquals(timestamp, encoded["createdAt"])
@@ -30,7 +32,7 @@ class TimestampTests {
     @Test
     fun encodeServerTimestampObject() = runTest {
         val timestamp = FieldValue.serverTimestamp()
-        val item = TestData("uid123", timestamp)
+        val item = TestData("uid123", timestamp, null)
         val encoded = encode(item, shouldEncodeElementDefault = false) as Map<String, Any?>
         assertEquals("uid123", encoded["uid"])
         assertEquals(timestamp, encoded["createdAt"])
@@ -46,5 +48,13 @@ class TimestampTests {
         val createdAt: Timestamp = timestamp
         assertEquals(123, createdAt.seconds)
         assertEquals(345, createdAt.nanoseconds)
+    }
+
+    @Test
+    fun decodeEmptyTimestampObject() = runTest {
+        val obj = mapOf("uid" to "uid123", "createdAt" to timestampNow(), "updatedAt" to Unit)
+        val decoded: TestData = decode(obj)
+        assertEquals("uid123", decoded.uid)
+        assertEquals(null, decoded.updatedAt)
     }
 }

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/TimestampTests.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/TimestampTests.kt
@@ -1,0 +1,50 @@
+package dev.gitlive.firebase.firestore
+
+import dev.gitlive.firebase.decode
+import dev.gitlive.firebase.encode
+import kotlinx.serialization.ImplicitReflectionSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TestData(
+    val uid: String,
+    @Serializable(with = FirebaseTimestampSerializer::class)
+    val createdAt: Any
+)
+
+@ImplicitReflectionSerializer
+@Suppress("UNCHECKED_CAST")
+class TimestampTests {
+
+    @Test
+    fun encodeTimestampObject() = runTest {
+        val timestamp = timestampWith(123, 456)
+        val item = TestData("uid123", timestamp)
+        val encoded = encode(item, shouldEncodeElementDefault = false) as Map<String, Any?>
+        assertEquals("uid123", encoded["uid"])
+        assertEquals(timestamp, encoded["createdAt"])
+    }
+
+    @Test
+    fun encodeServerTimestampObject() = runTest {
+        val timestamp = FieldValue.serverTimestamp()
+        val item = TestData("uid123", timestamp)
+        val encoded = encode(item, shouldEncodeElementDefault = false) as Map<String, Any?>
+        assertEquals("uid123", encoded["uid"])
+        assertEquals(timestamp, encoded["createdAt"])
+    }
+
+    @Test
+    fun decodeTimestampObject() = runTest {
+        val timestamp = timestampWith(123, 345)
+        val obj = mapOf("uid" to "uid123", "createdAt" to timestamp)
+        val decoded: TestData = decode(obj)
+        assertEquals("uid123", decoded.uid)
+        assertEquals(timestamp, decoded.createdAt)
+        val createdAt: Timestamp = timestamp
+        assertEquals(123, createdAt.seconds)
+        assertEquals(345, createdAt.nanoseconds)
+    }
+}

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -32,4 +32,9 @@ class FirebaseFirestoreTest {
     fun testClearPersistence() = runTest {
         Firebase.firestore.clearPersistence()
     }
+
+    @Test
+    fun testDefaultOptions() = runTest {
+        assertNull(FirebaseOptions.withContext(1))
+    }
 }

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -4,6 +4,6 @@ import cocoapods.FirebaseFirestore.FIRTimestamp
 
 actual typealias Timestamp = FIRTimestamp
 
-actual fun Timestamp.now(): Timestamp = FIRTimestamp.timestamp()
+actual fun timestampNow(): Timestamp = FIRTimestamp.timestamp()
 actual val Timestamp.seconds: Long get() = seconds
 actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -1,0 +1,9 @@
+package dev.gitlive.firebase.firestore
+
+import cocoapods.FirebaseFirestore.FIRTimestamp
+
+actual typealias Timestamp = FIRTimestamp
+
+actual fun Timestamp.now(): Timestamp = FIRTimestamp.timestamp()
+actual val Timestamp.seconds: Long get() = seconds
+actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -5,5 +5,6 @@ import cocoapods.FirebaseFirestore.FIRTimestamp
 actual typealias Timestamp = FIRTimestamp
 
 actual fun timestampNow(): Timestamp = FIRTimestamp.timestamp()
+actual fun timestampWith(seconds: Long, nanoseconds: Int) = FIRTimestamp(seconds, nanoseconds)
 actual val Timestamp.seconds: Long get() = seconds
 actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -32,6 +32,8 @@ actual class FirebaseFirestore(val ios: FIRFirestore) {
 
     actual fun document(documentPath: String) = DocumentReference(ios.documentWithPath(documentPath))
 
+    actual fun collectionGroup(collectionId: String) = Query(ios.collectionGroupWithID(collectionId))
+
     actual fun batch() = WriteBatch(ios.batch())
 
     actual fun setLoggingEnabled(loggingEnabled: Boolean): Unit =

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -320,6 +320,7 @@ actual object FieldValue {
     actual fun delete(): Any = FIRFieldValue.fieldValueForDelete()
     actual fun arrayUnion(vararg elements: Any): Any = FIRFieldValue.fieldValueForArrayUnion(elements.asList())
     actual fun arrayRemove(vararg elements: Any): Any = FIRFieldValue.fieldValueForArrayUnion(elements.asList())
+    actual fun serverTimestamp(): Any = FIRFieldValue.fieldValueForServerTimestamp()
 }
 
 private fun <T, R> T.throwError(block: T.(errorPointer: CPointer<ObjCObjectVar<NSError?>>) -> R): R {

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -231,11 +231,11 @@ actual class CollectionReference(override val ios: FIRCollectionReference) : Que
     actual val path: String
         get() = ios.path
 
-    actual suspend fun add(data: Any, encodeDefaults: Boolean) =
-        DocumentReference(await { ios.addDocumentWithData(encode(data, encodeDefaults) as Map<Any?, *>, it) })
+    actual suspend fun add(data: Any, encodeDefaults: Boolean, positiveInfinity: Any) =
+        DocumentReference(await { ios.addDocumentWithData(encode(data, encodeDefaults, positiveInfinity) as Map<Any?, *>, it) })
 
-    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
-        DocumentReference(await { ios.addDocumentWithData(encode(strategy, data, encodeDefaults) as Map<Any?, *>) })
+    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean, positiveInfinity: Any) =
+        DocumentReference(await { ios.addDocumentWithData(encode(strategy, data, encodeDefaults, positiveInfinity) as Map<Any?, *>) })
 }
 
 actual class FirebaseFirestoreException(message: String, val code: FirestoreExceptionCode) : FirebaseException(message)

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -231,11 +231,11 @@ actual class CollectionReference(override val ios: FIRCollectionReference) : Que
     actual val path: String
         get() = ios.path
 
-    actual suspend fun add(data: Any, encodeDefaults: Boolean, positiveInfinity: Any) =
-        DocumentReference(await { ios.addDocumentWithData(encode(data, encodeDefaults, positiveInfinity) as Map<Any?, *>, it) })
+    actual suspend fun add(data: Any, encodeDefaults: Boolean) =
+        DocumentReference(await { ios.addDocumentWithData(encode(data, encodeDefaults) as Map<Any?, *>, it) })
 
-    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean, positiveInfinity: Any) =
-        DocumentReference(await { ios.addDocumentWithData(encode(strategy, data, encodeDefaults, positiveInfinity) as Map<Any?, *>) })
+    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
+        DocumentReference(await { ios.addDocumentWithData(encode(strategy, data, encodeDefaults) as Map<Any?, *>) })
 }
 
 actual class FirebaseFirestoreException(message: String, val code: FirestoreExceptionCode) : FirebaseException(message)

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -1,0 +1,9 @@
+package dev.gitlive.firebase.firestore
+
+import dev.gitlive.firebase.*
+
+actual typealias Timestamp = firebase.firestore.Timestamp
+
+actual fun Timestamp.now(): Timestamp = Timestamp.now()
+actual val Timestamp.seconds: Long get() = seconds
+actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -5,5 +5,6 @@ import dev.gitlive.firebase.*
 actual typealias Timestamp = firebase.firestore.Timestamp
 
 actual fun timestampNow(): Timestamp = Timestamp.now()
+actual fun timestampWith(seconds: Long, nanoseconds: Int) = Timestamp(seconds, nanoseconds)
 actual val Timestamp.seconds: Long get() = seconds
 actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/Timestamp.kt
@@ -4,6 +4,6 @@ import dev.gitlive.firebase.*
 
 actual typealias Timestamp = firebase.firestore.Timestamp
 
-actual fun Timestamp.now(): Timestamp = Timestamp.now()
+actual fun timestampNow(): Timestamp = Timestamp.now()
 actual val Timestamp.seconds: Long get() = seconds
 actual val Timestamp.nanoseconds: Int get() = nanoseconds

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -32,6 +32,8 @@ actual class FirebaseFirestore(val js: firebase.firestore.Firestore) {
 
     actual fun document(documentPath: String) = rethrow { DocumentReference(js.doc(documentPath)) }
 
+    actual fun collectionGroup(collectionId: String) = rethrow { Query(js.collectionGroup(collectionId)) }
+
     actual fun batch() = rethrow { WriteBatch(js.batch()) }
 
     actual fun setLoggingEnabled(loggingEnabled: Boolean) =

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -302,11 +302,11 @@ actual class CollectionReference(override val js: firebase.firestore.CollectionR
     actual val path: String
         get() =  rethrow { js.path }
 
-    actual suspend fun add(data: Any, encodeDefaults: Boolean) =
-        rethrow { DocumentReference(js.add(encode(data, encodeDefaults)!!).await()) }
+    actual suspend fun add(data: Any, encodeDefaults: Boolean, positiveInfinity: Any) =
+        rethrow { DocumentReference(js.add(encode(data, encodeDefaults, positiveInfinity)!!).await()) }
 
-    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
-        rethrow { DocumentReference(js.add(encode(strategy, data, encodeDefaults)!!).await()) }
+    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean, positiveInfinity: Any) =
+        rethrow { DocumentReference(js.add(encode(strategy, data, encodeDefaults, positiveInfinity)!!).await()) }
 }
 
 actual class FirebaseFirestoreException(cause: Throwable, val code: FirestoreExceptionCode) : FirebaseException(code.toString(), cause)

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -350,6 +350,7 @@ actual object FieldValue {
     actual fun delete(): Any = rethrow { firebase.firestore.FieldValue.delete() }
     actual fun arrayUnion(vararg elements: Any): Any = rethrow { firebase.firestore.FieldValue.arrayUnion(*elements) }
     actual fun arrayRemove(vararg elements: Any): Any = rethrow { firebase.firestore.FieldValue.arrayRemove(*elements) }
+    actual fun serverTimestamp(): Any = rethrow { firebase.firestore.FieldValue.serverTimestamp() }
 }
 
 //actual data class FirebaseFirestoreSettings internal constructor(

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -302,11 +302,11 @@ actual class CollectionReference(override val js: firebase.firestore.CollectionR
     actual val path: String
         get() =  rethrow { js.path }
 
-    actual suspend fun add(data: Any, encodeDefaults: Boolean, positiveInfinity: Any) =
-        rethrow { DocumentReference(js.add(encode(data, encodeDefaults, positiveInfinity)!!).await()) }
+    actual suspend fun add(data: Any, encodeDefaults: Boolean) =
+        rethrow { DocumentReference(js.add(encode(data, encodeDefaults)!!).await()) }
 
-    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean, positiveInfinity: Any) =
-        rethrow { DocumentReference(js.add(encode(strategy, data, encodeDefaults, positiveInfinity)!!).await()) }
+    actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
+        rethrow { DocumentReference(js.add(encode(strategy, data, encodeDefaults)!!).await()) }
 }
 
 actual class FirebaseFirestoreException(cause: Throwable, val code: FirestoreExceptionCode) : FirebaseException(code.toString(), cause)


### PR DESCRIPTION
To have objects stored in Firestore all timestamp fields should be valid.
On Android it's `com.google.firebase.Timestamp`
On iOS it's `FIRTimestamp`

In same time, this timestamp value can be `FieldValue.serverTimestamp()` in case to user Server Value.

After creating new object with server timestamp, object will be returned with timestamp value `Unit`.

Based on:
https://github.com/andersio/firebase-kotlin-sdk/tree/anders/decoder
https://github.com/touchlab-lab/FirestoreKMP/blob/master/firestore/src/commonMain/kotlin/co/touchlab/firebase/firestore/Timestamp.kt

Also:

- `collectionGroup` added to fetch subcollection for given path
- `FirebaseOptions.withContext` added to create options from file
