### PR TITLE
Fix FirebaseDocumentReferenceSerializer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,12 +187,12 @@ subprojects {
 
         dependencies {
             "commonMainImplementation"(kotlin("stdlib-common"))
-            "commonMainImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
+            "commonMainImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2-native-mt")
             "jsMainImplementation"(kotlin("stdlib-js"))
-            "androidMainImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.2")
+            "androidMainImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.2-native-mt")
             "commonTestImplementation"(kotlin("test-common"))
             "commonTestImplementation"(kotlin("test-annotations-common"))
-            "commonTestImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
+            "commonTestImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2-native-mt")
             "jsTestImplementation"(kotlin("test-js"))
             "androidAndroidTestImplementation"(kotlin("test-junit"))
             "androidAndroidTestImplementation"("junit:junit:4.13")

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceEncoder.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceEncoder.kt
@@ -1,0 +1,7 @@
+package dev.gitlive.firebase.firestore
+
+actual class FirebaseDocumentReferenceEncoder actual constructor() {
+    actual fun encode(value: DocumentReference): Any {
+        return value.android
+    }
+}

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -359,6 +359,8 @@ actual val FirebaseFirestoreException.code: FirestoreExceptionCode get() = code
 actual typealias FirestoreExceptionCode = com.google.firebase.firestore.FirebaseFirestoreException.Code
 
 actual class QuerySnapshot(val android: com.google.firebase.firestore.QuerySnapshot) {
+    actual val documents
+        get() = android.documents.map { DocumentSnapshot(it) }
     actual val documentChanges
         get() = android.documentChanges.map { DocumentChange(it) }
     actual val metadata: SnapshotMetadata get() = SnapshotMetadata(android.metadata)

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceSerializer.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceSerializer.kt
@@ -9,7 +9,11 @@ import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-class DocumentReferenceSerializer : KSerializer<DocumentReference> {
+expect class FirebaseDocumentReferenceEncoder() {
+    fun encode(value: DocumentReference): Any
+}
+
+class FirebaseDocumentReferenceSerializer : KSerializer<DocumentReference> {
 
     override val descriptor = object : SerialDescriptor {
         val keys = listOf("path")
@@ -25,7 +29,8 @@ class DocumentReferenceSerializer : KSerializer<DocumentReference> {
 
     override fun serialize(encoder: Encoder, value: DocumentReference) {
         val objectEncoder = encoder.beginStructure(descriptor) as FirebaseCompositeEncoder
-        objectEncoder.encodeObject(descriptor, 0, value)
+        val documentReferenceEncoder = FirebaseDocumentReferenceEncoder()
+        objectEncoder.encodeObject(descriptor, 0, documentReferenceEncoder.encode(value))
         objectEncoder.endStructure(descriptor)
     }
 

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -167,6 +167,7 @@ expect enum class Direction {
 }
 
 expect class QuerySnapshot {
+    val documents: List<DocumentSnapshot>
     val documentChanges: List<DocumentChange>
     val metadata: SnapshotMetadata
 }

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -137,20 +137,4 @@ class FirebaseFirestoreTest {
     fun testDefaultOptions() = runTest {
         assertNull(FirebaseOptions.withContext(1))
     }
-
-    @Serializable
-    data class TestDataWithDocumentReference(
-        val uid: String,
-        @Serializable(with = DocumentReferenceSerializer::class)
-        val reference: DocumentReference
-    )
-
-    @Test
-    fun encodeDocumentReferenceObject() = runTest {
-        val doc = Firebase.firestore.document("a/b")
-        val item = TestDataWithDocumentReference("123", doc)
-        val encoded = encode(item, shouldEncodeElementDefault = false) as Map<String, Any?>
-        assertEquals("123", encoded["uid"])
-        assertEquals(doc, encoded["reference"])
-    }
 }

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceEncoder.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceEncoder.kt
@@ -1,0 +1,7 @@
+package dev.gitlive.firebase.firestore
+
+actual class FirebaseDocumentReferenceEncoder actual constructor() {
+    actual fun encode(value: DocumentReference): Any {
+        return value.ios
+    }
+}

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -318,6 +318,8 @@ fun NSError.toException() = when(domain) {
 }.let { FirebaseFirestoreException(description!!, it) }
 
 actual class QuerySnapshot(val ios: FIRQuerySnapshot) {
+    actual val documents
+        get() = ios.documents.map { DocumentSnapshot(it as FIRDocumentSnapshot) }
     actual val documentChanges
         get() = ios.documentChanges.map { DocumentChange(it as FIRDocumentChange) }
     actual val metadata: SnapshotMetadata get() = SnapshotMetadata(ios.metadata)

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceEncoder.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/FirebaseDocumentReferenceEncoder.kt
@@ -1,0 +1,7 @@
+package dev.gitlive.firebase.firestore
+
+actual class FirebaseDocumentReferenceEncoder actual constructor() {
+    actual fun encode(value: DocumentReference): Any {
+        return value.js
+    }
+}

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -335,6 +335,8 @@ actual class FirebaseFirestoreException(cause: Throwable, val code: FirestoreExc
 actual val FirebaseFirestoreException.code: FirestoreExceptionCode get() = code
 
 actual class QuerySnapshot(val js: firebase.firestore.QuerySnapshot) {
+    actual val documents
+        get() = js.docs.map { DocumentSnapshot(it) }
     actual val documentChanges
         get() = js.docChanges().map { DocumentChange(it) }
     actual val metadata: SnapshotMetadata get() = SnapshotMetadata(js.metadata)


### PR DESCRIPTION
In order to have Firestore Reference encoded correctly on platform side