### PR TITLE
Sign only tasks that publish to Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ subprojects {
     }
 
     tasks.withType<Sign>().configureEach {
-        onlyIf { !project.gradle.startParameter.taskNames.contains("publishToMavenLocal") }
+        onlyIf { project.gradle.startParameter.taskNames.contains("MavenRepository") }
     }
 
     tasks.whenTaskAdded {


### PR DESCRIPTION
This PR updates build script with the rule that **only** tasks that publish to Maven Central (or other non-local Maven) sign their artefacts.

It was tested with `./gradlew publish --dry-run`